### PR TITLE
replaces prices object on every run

### DIFF
--- a/src/graphql/createPrices.js
+++ b/src/graphql/createPrices.js
@@ -2,8 +2,9 @@ const { gql } = require('@apollo/client');
 
 const UPDATE_PRICES = gql`
 	mutation Mutation($priceObj: JSON) {
-  updatePrices(priceObj: $priceObj) {
-    count
+  createPrices(priceObj: $priceObj) {
+    timestamp
+	priceObj
   }
 }
 `;

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -123,9 +123,6 @@ const resolvers = {
 
 		updatePrices: async (parent, args) => prisma.prices.updateMany(
 			{
-				where: {
-					timestamp: { gt: 0 }
-				},
 				data: {
 					timestamp: Date.now(),
 					priceObj: args.priceObj

--- a/src/resolvers.js
+++ b/src/resolvers.js
@@ -44,7 +44,7 @@ const resolvers = {
 			prisma.bounty.findUnique({
 				where: { address: args.address },
 			}),
-		prices: async () => prisma.prices.findMany({ take: 10, orderBy: { timestamp: 'desc' } })
+		prices: async () => prisma.prices.findMany({ take: 1, orderBy: { timestamp: 'desc' } })
 
 
 	},
@@ -121,7 +121,23 @@ const resolvers = {
 				},
 			}),
 
-		updatePrices: async (parent, args) => prisma.prices.create(
+		updatePrices: async (parent, args) => prisma.prices.updateMany(
+			{
+				where: {
+					timestamp: { gt: 0 }
+				},
+				data: {
+					timestamp: Date.now(),
+					priceObj: args.priceObj
+				}
+
+			}
+
+		),
+
+
+
+		createPrices: async (parent, args) => prisma.prices.create(
 			{
 				data: {
 					timestamp: Date.now(),
@@ -130,6 +146,7 @@ const resolvers = {
 			}
 
 		),
+
 
 		watchBounty: async (parent, args) => {
 			const bounty = await prisma.bounty.findUnique({

--- a/src/schema.js
+++ b/src/schema.js
@@ -52,6 +52,11 @@ const typeDefs = gql`
 	type Prices {
 		timestamp: Float!
 		priceObj: JSON!
+		id: ID!
+	}
+
+	type BatchPayload {
+  		count: Int
 	}
 
 	type Query {
@@ -79,7 +84,8 @@ const typeDefs = gql`
 			tvl: Float!
 			organizationId: String
 		): Bounty!
-		updatePrices(priceObj: JSON):Prices!
+		updatePrices(priceObj: JSON):BatchPayload!
+		createPrices(priceObj: JSON):Prices!
 		watchBounty(userAddress: String, contractAddress: String): User
 		unWatchBounty(userAddress: String, contractAddress: String): User
 	}


### PR DESCRIPTION
Replaces upsert in updatePrices resolver with updateMany which updates all prices.
Adds createPrices resolver.
Uses a combination of updatePrices and createPrices to implment upsert like functionality in the indexer. (If a bounty is not updated because there are none, one will be created.
This allows us to keep the prices collection to just one price.