### PR TITLE
added createdAt field to mongo and appropriate resolvers for it.

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -19,6 +19,7 @@ model Bounty {
     watchingUsers   User[]        @relation(fields: [watchingUserIds], references: [address])
     organization    Organization? @relation(fields: [organizationId], references: [id])
     organizationId  String?
+    createdAt       DateTime      @default(now())
     prs             Pr[]
     views           Int           @default(0)
     blacklisted     Boolean

--- a/src/resolvers/bounty/bounties.js
+++ b/src/resolvers/bounty/bounties.js
@@ -3,18 +3,23 @@ const Bounties = {
 	bountyConnection: async (parent, args, { prisma }) => {
 		const cursor = parent.after ? { address: parent.after } : undefined;
 		const nodes = await prisma.bounty.findMany({
-			skip: (parent.orderBy === 'address' || !parent.after) ? 0 : 1,
+			skip: (!parent.after) ? 0 : 1,
 			cursor,
 			where: { organizationId: parent.organizationId, type: { in: parent.types }, category: parent.category, address: { in: parent.addresses } },
 			take: parent.limit,
-			...parent.orderBy && {
+			...parent.orderBy ? {
 				orderBy: [
 					{ [parent.orderBy]: parent.sortOrder },
 					{ [parent.orderBy || 'address']: parent.orderBy && parent.sortOrder },
 				],
-			},
+			} :
+				{
+					orderBy: {
+						createdAt: parent.sortOrder || 'desc'
+					}
+				}
+			,
 			include: { organization: true },
-
 
 		});
 		return {
@@ -23,16 +28,23 @@ const Bounties = {
 		};
 	},
 
+
 	nodes: async (parent, args, { prisma }) => {
 		const bounties = await prisma.bounty.findMany({
 			where: { organizationId: parent.organizationId, type: { in: parent.types }, category: parent.category, address: { in: parent.addresses } },
 			take: parent.limit,
-			...parent.orderBy && {
+			...parent.orderBy ? {
 				orderBy: [
 					{ [parent.orderBy]: parent.sortOrder },
 					{ [parent.orderBy || 'address']: parent.orderBy && parent.sortOrder },
 				],
-			},
+			} :
+				{
+					orderBy: {
+						createdAt: parent.sortOrder || 'desc'
+					}
+				}
+			,
 			include: { organization: true },
 
 		});

--- a/src/typeDefs/bounty/type.js
+++ b/src/typeDefs/bounty/type.js
@@ -12,6 +12,7 @@ const typeDef = gql`
 		organization: Organization
 		organizationId: String
 		category: String
+		createdAt: String
 	}
 	type Bounties {
 		bountyConnection: BountyConnection


### PR DESCRIPTION
Makes sorting by createdAt possible in the frontend.
Added createdAt as a default field to the prisma schema.
Added sorting by createdAt as the default for bountyConnection fields.
Added createdAt to the bounty type, so we can return it from the API.