### PR TITLE
Fixed sorting bug on staging and prod

### DIFF
--- a/src/resolvers/bounty/bounties.js
+++ b/src/resolvers/bounty/bounties.js
@@ -2,10 +2,11 @@
 const Bounties = {
 	bountyConnection: async (parent, args, { prisma }) => {
 		const cursor = parent.after ? { address: parent.after } : undefined;
+		const organizationIdObj = parent.organizationId ? { organizationId: parent.organizationId } : {};
 		const nodes = await prisma.bounty.findMany({
 			skip: (!parent.after) ? 0 : 1,
 			cursor,
-			where: { organizationId: parent.organizationId, type: { in: parent.types }, category: parent.category, address: { in: parent.addresses } },
+			where: { ...organizationIdObj, type: { in: parent.types }, category: parent.category, address: { in: parent.addresses } },
 			take: parent.limit,
 			...parent.orderBy ? {
 				orderBy: [
@@ -30,8 +31,9 @@ const Bounties = {
 
 
 	nodes: async (parent, args, { prisma }) => {
+		const organizationIdObj = parent.organizationId ? { organizationId: parent.organizationId } : {};
 		const bounties = await prisma.bounty.findMany({
-			where: { organizationId: parent.organizationId, type: { in: parent.types }, category: parent.category, address: { in: parent.addresses } },
+			where: { ...organizationIdObj, type: { in: parent.types }, category: parent.category, address: { in: parent.addresses } },
 			take: parent.limit,
 			...parent.orderBy ? {
 				orderBy: [


### PR DESCRIPTION
Currently sorting that requires fetching new data is not working on staging or prod. This is due to the api requiring an organizationId (for if you are fetching bounties only from a certain org)  in the body of the query. If it didn't recieve one it would send an empty array instead of all the bounties.

This pr makes the org id optional.