### PR TITLE
Adds bounties to retrun for repositories.

### DIFF
--- a/src/resolvers/bounty/mutation.js
+++ b/src/resolvers/bounty/mutation.js
@@ -113,7 +113,7 @@ const Mutation = {
 		const bounty = await prisma.bounty.findUnique({
 			where: { address },
 		});
-		const currentTvl = bounty.tvl;
+		const currentTvl = bounty?.tvl || 0;
 		const tvl = await calculateTvl(tokenBalance, currentTvl, add);
 		return prisma.bounty.update({
 			where: { address },

--- a/src/resolvers/repository/index.js
+++ b/src/resolvers/repository/index.js
@@ -1,9 +1,11 @@
 const Mutation = require('./mutation');
 const Query = require('./query');
+const Repository = require('./repository');
 
 const contestResolvers = {
 	Mutation,
-	Query
+	Query,
+	Repository
 };
 
 module.exports = contestResolvers;

--- a/src/resolvers/repository/repository.js
+++ b/src/resolvers/repository/repository.js
@@ -1,0 +1,9 @@
+const Repository = {
+	bounties: async (parent, args) => {
+		return { repositoryId: parent.id, ...args };
+	}
+
+
+};
+
+module.exports = Repository;


### PR DESCRIPTION
Needed to add a bounties resolver under Repository so that bounties would receive the correct query values from the resolver chain. The way I understand it, chained resolvers (like Bounties) take in the value returned by their parent resolver(in this case Repository.bounties) as the parent obj. If that doesn't exist or gives the wrong values Bounties will either never run or will receive null and return null.
